### PR TITLE
update bitcoin-tx to output witness data

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -151,11 +151,13 @@ void ScriptPubKeyToUniv(const CScript& scriptPubKey,
 void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
 {
     entry.pushKV("txid", tx.GetHash().GetHex());
+    entry.pushKV("hash", tx.GetWitnessHash().GetHex());
     entry.pushKV("version", tx.nVersion);
     entry.pushKV("locktime", (int64_t)tx.nLockTime);
 
     UniValue vin(UniValue::VARR);
-    BOOST_FOREACH(const CTxIn& txin, tx.vin) {
+    for (unsigned int i = 0; i < tx.vin.size(); i++) {
+        const CTxIn& txin = tx.vin[i];
         UniValue in(UniValue::VOBJ);
         if (tx.IsCoinBase())
             in.pushKV("coinbase", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
@@ -166,6 +168,16 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
             o.pushKV("asm", ScriptToAsmStr(txin.scriptSig, true));
             o.pushKV("hex", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
             in.pushKV("scriptSig", o);
+            if (!tx.wit.IsNull()) {
+                if (!tx.wit.vtxinwit[i].IsNull()) {
+                    UniValue txinwitness(UniValue::VARR);
+                    for (unsigned int j = 0; j < tx.wit.vtxinwit[i].scriptWitness.stack.size(); j++) {
+                        std::vector<unsigned char> item = tx.wit.vtxinwit[i].scriptWitness.stack[j];
+                        txinwitness.push_back(HexStr(item.begin(), item.end()));
+                    }
+                    in.pushKV("txinwitness", txinwitness);
+                }
+            }
         }
         in.pushKV("sequence", (int64_t)txin.nSequence);
         vin.push_back(in);


### PR DESCRIPTION
In https://github.com/bitcoin/bitcoin/commit/7c4bf779e8b74e474551982a24f5acc265293abd , jl2012 updated getrawtransaction() to return the witness data for transaction inputs spending P2WPK and P2WSH.

bitcoin-tx doesn't call into this function and instead calls `TxToUniv()` in `core_write.cpp`, so bitcoin-tx calls don't return witness data.

I think the proper fix is to have `getrawtransaction()` call into `TxToUniv()` so we don't have duplicate code. For now, I'm just adding code to `TxToUniv()` to return witness data.
