### PR TITLE
Only log block size if block size is being accounted

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -168,7 +168,11 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn)
     nLastBlockTx = nBlockTx;
     nLastBlockSize = nBlockSize;
     nLastBlockWeight = nBlockWeight;
-    LogPrintf("CreateNewBlock(): total size %u txs: %u fees: %ld sigops %d\n", nBlockSize, nBlockTx, nFees, nBlockSigOpsCost);
+    // If we're accounting for size, log size and weight. Otherwise just log weight.
+    if (fNeedSizeAccounting)
+        LogPrintf("CreateNewBlock(): total weight: %u total size %u txs: %u fees: %ld sigops %d\n", nBlockWeight, nBlockSize, nBlockTx, nFees, nBlockSigOpsCost);
+    else
+        LogPrintf("CreateNewBlock(): total weight %u txs: %u fees: %ld sigops %d\n", nBlockWeight, nBlockTx, nFees, nBlockSigOpsCost);
 
     // Create coinbase transaction.
     CMutableTransaction coinbaseTx;


### PR DESCRIPTION
bitcoind writes the following log when it's created a new block:

`CreateNewBlock(): total size _ txs: _ fees: _ sigops _`

If this is post-segwit and the miner is counting weight and not block size, then the size field will be incorrect (it will always be set to 1000).

This PR fixes the log in the following way:
- if the miner is not accounting for size, then only log the weight of the block.
- if the miner _is_ accounting for size, then log the size _and_ weight of the block.

I've run all tests and manually verified that the log output is correct when using the `blockmaxsize` and `blockmaxweight` command line parameters.
