### PR TITLE
Replace map in mempool with an unordered multimap.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -96,6 +96,7 @@ BITCOIN_CORE_H = \
   httprpc.h \
   httpserver.h \
   indirectmap.h \
+  unordered_indirect_multimap.h \
   init.h \
   key.h \
   keystore.h \
@@ -359,7 +360,7 @@ bitcoind_LDADD = \
   $(LIBMEMENV) \
   $(LIBSECP256K1)
 
-bitcoind_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(ZMQ_LIBS)
+bitcoind_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(ZMQ_LIBS) -lprofiler
 
 # bitcoin-cli binary #
 bitcoin_cli_SOURCES = bitcoin-cli.cpp
@@ -377,7 +378,7 @@ bitcoin_cli_LDADD = \
   $(LIBBITCOIN_UTIL) \
   $(LIBBITCOIN_CRYPTO)
 
-bitcoin_cli_LDADD += $(BOOST_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(EVENT_LIBS)
+bitcoin_cli_LDADD += $(BOOST_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(EVENT_LIBS) -lprofiler
 #
 
 # bitcoin-tx binary #

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -6,6 +6,7 @@
 #define BITCOIN_MEMUSAGE_H
 
 #include "indirectmap.h"
+#include "unordered_indirect_multimap.h"
 
 #include <stdlib.h>
 
@@ -127,6 +128,20 @@ static inline size_t DynamicUsage(const indirectmap<X, Y>& m)
 
 template<typename X, typename Y>
 static inline size_t IncrementalDynamicUsage(const indirectmap<X, Y>& m)
+{
+    return MallocUsage(sizeof(stl_tree_node<std::pair<const X*, Y> >));
+}
+
+// unordered_indirect_multimap has underlying map with pointer as key
+
+template<typename X, typename Y>
+static inline size_t DynamicUsage(const unordered_indirect_multimap<X, Y>& m)
+{
+    return MallocUsage(sizeof(stl_tree_node<std::pair<const X*, Y> >)) * m.size();
+}
+
+template<typename X, typename Y>
+static inline size_t IncrementalDynamicUsage(const unordered_indirect_multimap<X, Y>& m)
 {
     return MallocUsage(sizeof(stl_tree_node<std::pair<const X*, Y> >));
 }

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -132,20 +132,6 @@ static inline size_t IncrementalDynamicUsage(const indirectmap<X, Y>& m)
     return MallocUsage(sizeof(stl_tree_node<std::pair<const X*, Y> >));
 }
 
-// unordered_indirect_multimap has underlying map with pointer as key
-
-template<typename X, typename Y>
-static inline size_t DynamicUsage(const unordered_indirect_multimap<X, Y>& m)
-{
-    return MallocUsage(sizeof(stl_tree_node<std::pair<const X*, Y> >)) * m.size();
-}
-
-template<typename X, typename Y>
-static inline size_t IncrementalDynamicUsage(const unordered_indirect_multimap<X, Y>& m)
-{
-    return MallocUsage(sizeof(stl_tree_node<std::pair<const X*, Y> >));
-}
-
 template<typename X>
 static inline size_t DynamicUsage(const std::unique_ptr<X>& p)
 {
@@ -180,6 +166,20 @@ template<typename X, typename Y, typename Z>
 static inline size_t DynamicUsage(const boost::unordered_map<X, Y, Z>& m)
 {
     return MallocUsage(sizeof(boost_unordered_node<std::pair<const X, Y> >)) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
+}
+
+// unordered_indirect_multimap has underlying map with pointer as key
+
+template<typename X, typename Y>
+static inline size_t DynamicUsage(const unordered_indirect_multimap<X, Y>& m)
+{
+    return MallocUsage(sizeof(boost_unordered_node<std::pair<const X*, Y> >)) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
+}
+
+template<typename X, typename Y>
+static inline size_t IncrementalDynamicUsage(const unordered_indirect_multimap<X, Y>& m)
+{
+    return MallocUsage(sizeof(boost_unordered_node<std::pair<const X*, Y> >));
 }
 
 }

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -542,8 +542,11 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     pool.TrimToSize(pool.DynamicMemoryUsage() / 2); // should maximize mempool size by only removing 5/7
     BOOST_CHECK(pool.exists(tx4.GetHash()));
     BOOST_CHECK(!pool.exists(tx5.GetHash()));
-    BOOST_CHECK(pool.exists(tx6.GetHash()));
     BOOST_CHECK(!pool.exists(tx7.GetHash()));
+
+    // Maybe 6 got bumped too.
+    if (!pool.exists(tx6.GetHash()))
+        pool.addUnchecked(tx6.GetHash(), entry.Fee(1100LL).FromTx(tx5, &pool));
 
     pool.addUnchecked(tx5.GetHash(), entry.Fee(1000LL).FromTx(tx5, &pool));
     pool.addUnchecked(tx7.GetHash(), entry.Fee(9000LL).FromTx(tx7, &pool));

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -429,6 +429,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     TestMemPoolEntryHelper entry;
     entry.dPriority = 10.0;
 
+    printf("1 size %d\n", (int)pool.DynamicMemoryUsage());
     CMutableTransaction tx1 = CMutableTransaction();
     tx1.vin.resize(1);
     tx1.vin[0].scriptSig = CScript() << OP_1;
@@ -472,6 +473,8 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     BOOST_CHECK(!pool.exists(tx1.GetHash()));
     BOOST_CHECK(!pool.exists(tx2.GetHash()));
     BOOST_CHECK(!pool.exists(tx3.GetHash()));
+
+    printf("1.5 size %d tx1: %d\n", (int)pool.DynamicMemoryUsage(), (int)GetVirtualTransactionSize(tx1));
 
     CFeeRate maxFeeRateRemoved(25000, GetVirtualTransactionSize(tx3) + GetVirtualTransactionSize(tx2));
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
@@ -540,8 +543,10 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     pool.addUnchecked(tx7.GetHash(), entry.Fee(9000LL).FromTx(tx7, &pool));
 
     pool.TrimToSize(pool.DynamicMemoryUsage() / 2); // should maximize mempool size by only removing 5/7
+    printf("2 size %d\n", (int)pool.DynamicMemoryUsage());
     BOOST_CHECK(pool.exists(tx4.GetHash()));
     BOOST_CHECK(!pool.exists(tx5.GetHash()));
+    BOOST_CHECK(pool.exists(tx6.GetHash()));
     BOOST_CHECK(!pool.exists(tx7.GetHash()));
 
     // Maybe 6 got bumped too.

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1110,6 +1110,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<uint256>* pvNoSpendsRe
     unsigned nTxnRemoved = 0;
     CFeeRate maxFeeRateRemoved(0);
     while (!mapTx.empty() && DynamicMemoryUsage() > sizelimit) {
+        printf("trimming; size: %d\n", (int)DynamicMemoryUsage());
         indexed_transaction_set::index<descendant_score>::type::iterator it = mapTx.get<descendant_score>().begin();
 
         // We set the new mempool min fee to the feerate of the removed set, plus the

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -696,12 +696,16 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
                 assert(coins && coins->IsAvailable(txin.prevout.n));
             }
             // Check whether its inputs are marked in mapSpenders.
-	    assert(mapSpenders.count(txin.prevout.hash) != 0);
+            assert(mapSpenders.count(txin.prevout.hash) != 0);
             auto it3 = mapSpenders.equal_range(txin.prevout.hash);
-	    for (auto it4 = it3.first; it4 != it3.second; ++it4) {
-		assert(it4->second.n == txin.prevout.n);
-		assert(it4->second.tx == &tx);
-	    }
+            bool found_vin = false;
+            for (auto it4 = it3.first; it4 != it3.second; ++it4) {
+                if (it4->second.n == txin.prevout.n) {
+                    found_vin = true;
+                    assert(it4->second.tx == &tx);
+                }
+                assert(found_vin);
+            }
         }
         assert(setParentCheck == GetMemPoolParents(it));
         // Verify ancestor state is correct.

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -15,6 +15,7 @@
 #include "indirectmap.h"
 #include "primitives/transaction.h"
 #include "sync.h"
+#include "unordered_indirect_multimap.h"
 
 #undef foreach
 #include "boost/multi_index_container.hpp"
@@ -490,7 +491,13 @@ private:
     std::vector<indexed_transaction_set::const_iterator> GetSortedDepthAndScore() const;
 
 public:
+    struct Out {
+      uint32_t n;
+      const CTransaction* tx;
+    };
+
     indirectmap<COutPoint, const CTransaction*> mapNextTx;
+    unordered_indirect_multimap<uint256, Out> mapSpenders;
     std::map<uint256, std::pair<double, CAmount> > mapDeltas;
 
     /** Create a new CTxMemPool.

--- a/src/unordered_indirect_multimap.h
+++ b/src/unordered_indirect_multimap.h
@@ -48,6 +48,7 @@ public:
     // passthrough
     bool empty() const              { return m.empty(); }
     size_type size() const          { return m.size(); }
+    size_type bucket_count() const  { return m.bucket_count(); }
     size_type max_size() const      { return m.max_size(); }
     void clear()                    { m.clear(); }
     iterator begin()                { return m.begin(); }

--- a/src/unordered_indirect_multimap.h
+++ b/src/unordered_indirect_multimap.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UNORDERED_INDIRECT_MULTIMAP_H
+#define BITCOIN_UNORDERED_INDIRECT_MULTIMAP_H
+
+#include <unordered_map>
+
+template <class T>
+struct DereferencingEqual { bool operator()(const T a, const T b) const { return *a == *b; } };
+template <class T>
+struct DereferencingHash  { std::size_t operator()(const T a) const { return (*a).GetCheapHash(); } };
+
+/* Unordered multimap whose keys are pointers, but are compared by
+ * their dereferenced values.
+ *
+ * See indirectmap.h for how this differs from a plain
+ * std::unordered_multimap<const K*, T, DereferencingEqual<K*>
+ * DereferencingHash<K*> >.
+ *
+ * Objects pointed to by keys must not be modified in any way that
+ * changes the result of DereferencingEqual or DereferencingHash.
+ */
+template <class K, class T>
+class unordered_indirect_multimap {
+private:
+    typedef std::unordered_multimap<const K*, T, DereferencingHash<const K*>, DereferencingEqual<const K*> > base;
+    base m;
+public:
+    typedef typename base::iterator iterator;
+    typedef typename base::const_iterator const_iterator;
+    typedef typename base::size_type size_type;
+    typedef typename base::value_type value_type;
+
+    // passthrough (pointer interface)
+    iterator insert(const value_type& value) { return m.insert(value); }
+
+    // pass address (value interface)
+    iterator find(const K& key)                                               { return m.find(&key); }
+    const_iterator find(const K& key) const                                   { return m.find(&key); }
+    std::pair<iterator,iterator> equal_range(const K& key)                    { return m.equal_range(&key); }
+    std::pair<const_iterator,const_iterator> equal_range(const K& key) const  { return m.equal_range(&key); }
+    size_type erase(const K& key)                                             { return m.erase(&key); }
+    iterator erase(iterator itr)                                              { return m.erase(itr); }
+    size_type count(const K& key) const                                       { return m.count(&key); }
+
+    // passthrough
+    bool empty() const              { return m.empty(); }
+    size_type size() const          { return m.size(); }
+    size_type max_size() const      { return m.max_size(); }
+    void clear()                    { m.clear(); }
+    iterator begin()                { return m.begin(); }
+    iterator end()                  { return m.end(); }
+    const_iterator begin() const    { return m.begin(); }
+    const_iterator end() const      { return m.end(); }
+    const_iterator cbegin() const   { return m.cbegin(); }
+    const_iterator cend() const     { return m.cend(); }
+};
+
+#endif // BITCOIN_UNORDERED_INDIRECT_MULTIMAP_H


### PR DESCRIPTION
This breaks the MempoolSizeLimitTest, line 545, but only when running all 210 tests (not just the mempool_tests).

I just created this for Wlad to look at.
