### PR TITLE
WIP: rework rescan logic - index side

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -156,6 +156,7 @@ BITCOIN_CORE_H = \
   netmessagemaker.h \
   node/coin.h \
   node/psbt.h \
+  node/rescan.h \
   node/transaction.h \
   noui.h \
   optional.h \
@@ -277,6 +278,7 @@ libbitcoin_server_a_SOURCES = \
   net_processing.cpp \
   node/coin.cpp \
   node/psbt.cpp \
+  node/rescan.cpp \
   node/transaction.cpp \
   noui.cpp \
   policy/fees.cpp \

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -43,13 +43,13 @@ const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
  * Use the buttons <code>Namespaces</code>, <code>Classes</code> or <code>Files</code> at the top of the page to start navigating the code.
  */
 
-static void WaitForShutdown()
+static void WaitForShutdown(InitInterfaces& interfaces)
 {
     while (!ShutdownRequested())
     {
         MilliSleep(200);
     }
-    Interrupt();
+    Interrupt(interfaces);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -172,9 +172,9 @@ static bool AppInit(int argc, char* argv[])
 
     if (!fRet)
     {
-        Interrupt();
+        Interrupt(interfaces);
     } else {
-        WaitForShutdown();
+        WaitForShutdown(interfaces);
     }
     Shutdown(interfaces);
 

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -218,7 +218,7 @@ bool BlockFilterIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex
     uint256 prev_header;
 
     if (pindex->nHeight > 0) {
-        if (!UndoReadFromDisk(block_undo, pindex)) {
+        if (!UndoReadFromDisk(block_undo, pindex->GetUndoPos(), pindex->GetBlockHash())) {
             return false;
         }
 

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -31,21 +31,23 @@ private:
     size_t WriteFilterToDisk(FlatFilePos& pos, const BlockFilter& filter);
 
 protected:
-    bool Init() override;
 
     bool CommitInternal(CDBBatch& batch) override;
 
-    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
+    bool WriteBlock(const CBlock& block, int height, FlatFilePos undo_pos, uint256& prev_hash) override;
 
-    bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
+    void Rewind(int forked_height, int ancestor_height) override;
 
     BaseIndex::DB& GetDB() const override { return *m_db; }
 
     const char* GetName() const override { return m_name.c_str(); }
 
 public:
+    /// Initialize internal state from the database and block index.
+    bool Init() override;
+
     /** Constructs the index, which becomes available to be queried. */
-    explicit BlockFilterIndex(BlockFilterType filter_type,
+    explicit BlockFilterIndex(BlockFilterType filter_type, interfaces::Chain& chain,
                               size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     BlockFilterType GetFilterType() const { return m_filter_type; }
@@ -78,7 +80,7 @@ void ForEachBlockFilterIndex(std::function<void (BlockFilterIndex&)> fn);
  * Initialize a block filter index for the given type if one does not already exist. Returns true if
  * a new index is created and false if one has already been initialized.
  */
-bool InitBlockFilterIndex(BlockFilterType filter_type,
+bool InitBlockFilterIndex(BlockFilterType filter_type, interfaces::Chain& chain,
                           size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
 /**

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -224,8 +224,9 @@ bool TxIndex::DB::MigrateData(CBlockTreeDB& block_tree_db, const CBlockLocator& 
     return true;
 }
 
-TxIndex::TxIndex(size_t n_cache_size, bool f_memory, bool f_wipe)
-    : m_db(MakeUnique<TxIndex::DB>(n_cache_size, f_memory, f_wipe))
+TxIndex::TxIndex(interfaces::Chain& chain, size_t n_cache_size, bool f_memory, bool f_wipe)
+    : BaseIndex(chain),
+      m_db(MakeUnique<TxIndex::DB>(n_cache_size, f_memory, f_wipe))
 {}
 
 TxIndex::~TxIndex() {}
@@ -244,12 +245,12 @@ bool TxIndex::Init()
     return BaseIndex::Init();
 }
 
-bool TxIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
+bool TxIndex::WriteBlock(const CBlock& block, int height, FlatFilePos block_pos, uint256& prev_hash)
 {
     // Exclude genesis block transaction because outputs are not spendable.
-    if (pindex->nHeight == 0) return true;
+    if (height == 0) return true;
 
-    CDiskTxPos pos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size()));
+    CDiskTxPos pos(block_pos, GetSizeOfCompactSize(block.vtx.size()));
     std::vector<std::pair<uint256, CDiskTxPos>> vPos;
     vPos.reserve(block.vtx.size());
     for (const auto& tx : block.vtx) {

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -23,18 +23,19 @@ private:
     const std::unique_ptr<DB> m_db;
 
 protected:
-    /// Override base class init to migrate from old database.
-    bool Init() override;
 
-    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
+    bool WriteBlock(const CBlock& block, int height, FlatFilePos undo_pos, uint256& prev_hash) override;
 
     BaseIndex::DB& GetDB() const override;
 
     const char* GetName() const override { return "txindex"; }
 
 public:
+    /// Override base class init to migrate from old database.
+    bool Init() override;
+
     /// Constructs the index, which becomes available to be queried.
-    explicit TxIndex(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit TxIndex(interfaces::Chain& chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     // Destructor is declared because this class contains a unique_ptr to an incomplete type.
     virtual ~TxIndex() override;

--- a/src/init.h
+++ b/src/init.h
@@ -28,7 +28,7 @@ class thread_group;
 } // namespace boost
 
 /** Interrupt threads */
-void Interrupt();
+void Interrupt(InitInterfaces& interfaces);
 void Shutdown(InitInterfaces& interfaces);
 //!Initialize the logging infrastructure
 void InitLogging();

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -188,7 +188,7 @@ public:
         const CBlockIndex* index,
         const std::vector<CTransactionRef>& tx_conflicted) override
     {
-        m_notifications->BlockConnected(*block, tx_conflicted, index->nHeight);
+        m_notifications->BlockConnected(*block, tx_conflicted, index->nHeight, index->GetUndoPos());
     }
     void BlockDisconnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -188,11 +188,11 @@ public:
         const CBlockIndex* index,
         const std::vector<CTransactionRef>& tx_conflicted) override
     {
-        m_notifications->BlockConnected(*block, tx_conflicted);
+        m_notifications->BlockConnected(*block, tx_conflicted, index->nHeight);
     }
-    void BlockDisconnected(const std::shared_ptr<const CBlock>& block) override
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {
-        m_notifications->BlockDisconnected(*block);
+        m_notifications->BlockDisconnected(*block, index->nHeight);
     }
     void UpdatedBlockTip(const CBlockIndex* index, const CBlockIndex* fork_index, bool is_ibd) override
     {

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -11,6 +11,7 @@
 #include <net.h>
 #include <net_processing.h>
 #include <node/coin.h>
+#include <node/rescan.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
@@ -244,6 +245,8 @@ public:
 
 class ChainImpl : public Chain
 {
+private:
+    Rescan m_rescan;
 public:
     std::unique_ptr<Chain::Lock> lock(bool try_lock) override
     {
@@ -349,6 +352,22 @@ public:
     std::unique_ptr<Handler> handleNotifications(Notifications& notifications) override
     {
         return MakeUnique<NotificationsHandlerImpl>(*this, notifications);
+    }
+    void startNotifications() override
+    {
+	m_rescan.StartServiceRequests();
+    }
+    void interruptNotifications() override
+    {
+        m_rescan.InterruptServiceRequests();
+    }
+    void stopNotifications() override
+    {
+	m_rescan.StopServiceRequests();
+    }
+    void registerNotifications(Notifications& callback, const CBlockLocator& locator) override
+    {
+        m_rescan.AddRequest(callback, locator);
     }
     void waitForNotificationsIfNewBlocksConnected(const uint256& old_tip) override
     {

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -21,6 +21,7 @@ class CRPCCommand;
 class CScheduler;
 class CValidationState;
 class Coin;
+class Rescan;
 class uint256;
 enum class RBFTransactionState;
 struct CBlockLocator;
@@ -242,6 +243,18 @@ public:
 
     //! Register handler for notifications.
     virtual std::unique_ptr<Handler> handleNotifications(Notifications& notifications) = 0;
+
+    //! Start notifications sequence in order for every ChainClient, used once by init code.
+    virtual void startNotifications() = 0;
+
+    //! Stop notifications sequence, used once by shutdown code.
+    virtual void stopNotifications() = 0;
+
+    //! Interrupt notification sequence, used once by interrupt code.
+    virtual void interruptNotifications() = 0;
+
+    //! Request notifications.
+    virtual void registerNotifications(interfaces::Chain::Notifications& callback, const CBlockLocator& locator) = 0;
 
     //! Wait for pending notifications to be processed unless block hash points to the current
     //! chain tip, or to a possible descendant of the current chain tip that isn't currently

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -231,8 +231,8 @@ public:
         virtual ~Notifications() {}
         virtual void TransactionAddedToMempool(const CTransactionRef& tx) {}
         virtual void TransactionRemovedFromMempool(const CTransactionRef& ptx) {}
-        virtual void BlockConnected(const CBlock& block, const std::vector<CTransactionRef>& tx_conflicted) {}
-        virtual void BlockDisconnected(const CBlock& block) {}
+        virtual void BlockConnected(const CBlock& block, const std::vector<CTransactionRef>& tx_conflicted, int height) {}
+        virtual void BlockDisconnected(const CBlock& block, int height) {}
         virtual void UpdatedBlockTip() {}
         virtual void ChainStateFlushed(const CBlockLocator& locator) {}
     };

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -236,6 +236,7 @@ public:
         virtual void BlockDisconnected(const CBlock& block, int height) {}
         virtual void UpdatedBlockTip() {}
         virtual void ChainStateFlushed(const CBlockLocator& locator) {}
+        virtual void Rewind(int forked_height, int ancestor_height) {}
     };
 
     //! Register handler for notifications.

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -237,6 +237,7 @@ public:
         virtual void UpdatedBlockTip() {}
         virtual void ChainStateFlushed(const CBlockLocator& locator) {}
         virtual void Rewind(int forked_height, int ancestor_height) {}
+        virtual void HandleNotifications() {}
     };
 
     //! Register handler for notifications.

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_INTERFACES_CHAIN_H
 #define BITCOIN_INTERFACES_CHAIN_H
 
+#include <chain.h>                  // For FlatFilePos
 #include <optional.h>               // For Optional and nullopt
 #include <primitives/transaction.h> // For CTransactionRef
 
@@ -231,7 +232,7 @@ public:
         virtual ~Notifications() {}
         virtual void TransactionAddedToMempool(const CTransactionRef& tx) {}
         virtual void TransactionRemovedFromMempool(const CTransactionRef& ptx) {}
-        virtual void BlockConnected(const CBlock& block, const std::vector<CTransactionRef>& tx_conflicted, int height) {}
+        virtual void BlockConnected(const CBlock& block, const std::vector<CTransactionRef>& tx_conflicted, int height, FlatFilePos undo_pos) {}
         virtual void BlockDisconnected(const CBlock& block, int height) {}
         virtual void UpdatedBlockTip() {}
         virtual void ChainStateFlushed(const CBlockLocator& locator) {}

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -78,7 +78,7 @@ public:
     bool appInitMain() override { return AppInitMain(m_interfaces); }
     void appShutdown() override
     {
-        Interrupt();
+        Interrupt(m_interfaces);
         Shutdown(m_interfaces);
     }
     void startShutdown() override { StartShutdown(); }

--- a/src/node/rescan.cpp
+++ b/src/node/rescan.cpp
@@ -1,0 +1,108 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/rescan.h>
+
+#include <chainparams.h>
+#include <primitives/block.h>
+#include <util/system.h>
+#include <validation.h>
+#include <validationinterface.h>
+
+void Rescan::ThreadServiceRequests()
+{
+    auto& consensus_params = Params().GetConsensus();
+    while (!m_interrupt) {
+        // Loop for the earliest start position among requests.
+        const CBlockIndex* min_start = nullptr;
+        const CBlockIndex* ancestor = nullptr;
+        for (auto& request : m_request_start) {
+            // If locator has not been found, request is handled
+            // since genesis.
+            if (!request.second) {
+                LOCK(cs_main);
+                request.second = ChainActive().Genesis();
+                if (!request.second) continue;
+            }
+            // Find fork between chain tip and client
+            // local view, if there is one, ask client to rewind
+            // its state until common ancestor
+            {
+                LOCK(cs_main);
+                ancestor = ChainActive().FindFork(request.second);
+            }
+            if (ancestor && ancestor->nHeight != (request.second)->nHeight) {
+                (request.first)->Rewind((request.second)->nHeight, ancestor->nHeight);
+                request.second = ancestor;
+            }
+            if (!min_start || min_start->nHeight > (request.second)->nHeight) {
+                min_start = request.second;
+            }
+        }
+        if (min_start) {
+            // Read next block and send notifications.
+            const CBlockIndex* next = nullptr;
+            {
+                LOCK(cs_main);
+		if (min_start->nHeight > 0) {
+                    assert(min_start->pprev);
+                    next = ChainActive().Next(min_start->pprev);
+                } else {
+                    next = min_start;
+                }
+            }
+            if (next) {
+                CBlock block;
+                ReadBlockFromDisk(block, next, consensus_params);
+                for (auto& request : m_request_start) {
+                    (request.first)->BlockConnected(block, {}, next->nHeight, next->GetUndoPos());
+                    request.second = next;
+                    // To avoid any race condition where callback would miss block connection,
+                    // compare against tip and register validation interface in one sequence
+                    LOCK(cs_main);
+                    CBlockIndex* tip = ChainActive().Tip();
+                    CBlockIndex* pindex = LookupBlockIndex(block.GetHash());
+                    if (tip->GetBlockHash() == pindex->GetBlockHash()) {
+                        (request.first)->UpdatedBlockTip(); // If client need to flush its state we signal tip is reached
+                        (request.first)->HandleNotifications();
+                        m_request_start.erase(request.first);
+                    }
+                }
+            }
+        }
+    }
+    // Be nice, let's requesters who need it, commit their database before to leave
+    for (auto& request : m_request_start) {
+        if (!request.second) continue;
+        LOCK(cs_main);
+        CBlockLocator locator = ::ChainActive().GetLocator(request.second);
+        (request.first)->ChainStateFlushed(locator);
+    }
+}
+
+void Rescan::AddRequest(interfaces::Chain::Notifications& callback, const CBlockLocator& locator)
+{
+    LOCK(cs_main);
+    // If fork is superior at MAX_LOCATOR_SZ, rescan is going to be processed
+    // from genesis. If reorg of this size happens, rescan performance hit
+    // isn't the main problem.
+    m_request_start[&callback] = FindForkInGlobalIndex(::ChainActive(), locator);
+}
+
+void Rescan::StartServiceRequests()
+{
+    threadServiceRequests = std::thread(&TraceThread<std::function<void()>>, "rescan", std::bind(&Rescan::ThreadServiceRequests, this));
+}
+
+void Rescan::InterruptServiceRequests()
+{
+    m_interrupt();
+}
+
+void Rescan::StopServiceRequests()
+{
+    if (threadServiceRequests.joinable()) {
+        threadServiceRequests.join();
+    }
+}

--- a/src/node/rescan.h
+++ b/src/node/rescan.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2017-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_RESCAN_H
+#define BITCOIN_NODE_RESCAN_H
+
+#include <interfaces/chain.h>
+#include <threadinterrupt.h>
+
+class CBlockIndex;
+
+//! Wallets or indexes can be fallen-behind chain tip at restart. They need
+//! to learn about blocks connected during their shutdown to update their
+//! internal states accordingly. If we have many wallets or indexes, each
+//! of them is going to read the same scan range repeatedly out of order
+//! instead of just once in order. To avoid that, Rescan accept
+//! rescan request at initialization and fulfill all of them in a thread
+//! ThreadServiceRequests started/stopped at init/shutdown sequences.
+class Rescan
+{
+private:
+    std::map<interfaces::Chain::Notifications *, const CBlockIndex*> m_request_start;
+    //TODO: Future plan is to use a thread pool with multiple workers to process
+    // rescan requests in parallel beyond clients loading
+    std::thread threadServiceRequests;
+    CThreadInterrupt m_interrupt;
+
+    //! Read blocks in sequence, consolidating rescan requests and send notifications in sequence
+    //! to all requesters.
+    void ThreadServiceRequests();
+
+public:
+    //! Add rescan request, using the passed callback handler to reditect block to, starting from
+    //! locator.
+    void AddRequest(interfaces::Chain::Notifications& callback, const CBlockLocator& locator);
+
+    //! Start thread worker to replay blocks for registered requester.
+    void StartServiceRequests();
+
+    //! Interrupt thread worker replaying blocks.
+    void InterruptServiceRequests();
+
+    //! Stop thread worker replaying blocks.
+    void StopServiceRequests();
+};
+
+#endif // BITCOIN_NODE_RESCAN_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -808,7 +808,7 @@ static CBlockUndo GetUndoChecked(const CBlockIndex* pblockindex)
         throw JSONRPCError(RPC_MISC_ERROR, "Undo data not available (pruned data)");
     }
 
-    if (!UndoReadFromDisk(blockUndo, pblockindex)) {
+    if (!UndoReadFromDisk(blockUndo, pblockindex->GetUndoPos(), pblockindex->pprev->GetBlockHash())) {
         throw JSONRPCError(RPC_MISC_ERROR, "Can't read undo data from disk");
     }
 

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -26,7 +26,7 @@ static bool ComputeFilter(BlockFilterType filter_type, const CBlockIndex* block_
     }
 
     CBlockUndo block_undo;
-    if (block_index->nHeight > 0 && !UndoReadFromDisk(block_undo, block_index)) {
+    if (block_index->nHeight > 0 && !UndoReadFromDisk(block_undo, block_index->GetUndoPos(), pindex->prev->GetBlockHash())) {
         return false;
     }
 

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -44,9 +44,10 @@ struct TestSubscriber : public CValidationInterface {
         m_expected_tip = block->GetHash();
     }
 
-    void BlockDisconnected(const std::shared_ptr<const CBlock>& block) override
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex) override
     {
         BOOST_CHECK_EQUAL(m_expected_tip, block->GetHash());
+        BOOST_CHECK_EQUAL(m_expected_tip, pindex->GetBlockHash());
 
         m_expected_tip = block->hashPrevBlock;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2221,7 +2221,7 @@ bool CChainState::DisconnectTip(CValidationState& state, const CChainParams& cha
     UpdateTip(pindexDelete->pprev, chainparams);
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
-    GetMainSignals().BlockDisconnected(pblock);
+    GetMainSignals().BlockDisconnected(pblock, pindexDelete);
     return true;
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -373,7 +373,7 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex, const CMessageHeader::MessageStartChars& message_start);
 
-bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
+bool UndoReadFromDisk(CBlockUndo& blockundo, FlatFilePos pos, uint256 prev_hash);
 
 /** Functions for validating blocks and updating the block tree */
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -31,7 +31,7 @@ struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;
     boost::signals2::signal<void (const CTransactionRef &)> TransactionAddedToMempool;
     boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex, const std::vector<CTransactionRef>&)> BlockConnected;
-    boost::signals2::signal<void (const std::shared_ptr<const CBlock> &)> BlockDisconnected;
+    boost::signals2::signal<void(const std::shared_ptr<const CBlock>&, const CBlockIndex* pindex)> BlockDisconnected;
     boost::signals2::signal<void (const CTransactionRef &)> TransactionRemovedFromMempool;
     boost::signals2::signal<void (const CBlockLocator &)> ChainStateFlushed;
     boost::signals2::signal<void (const CBlock&, const CValidationState&)> BlockChecked;
@@ -94,7 +94,7 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     conns.UpdatedBlockTip = g_signals.m_internals->UpdatedBlockTip.connect(std::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     conns.TransactionAddedToMempool = g_signals.m_internals->TransactionAddedToMempool.connect(std::bind(&CValidationInterface::TransactionAddedToMempool, pwalletIn, std::placeholders::_1));
     conns.BlockConnected = g_signals.m_internals->BlockConnected.connect(std::bind(&CValidationInterface::BlockConnected, pwalletIn, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-    conns.BlockDisconnected = g_signals.m_internals->BlockDisconnected.connect(std::bind(&CValidationInterface::BlockDisconnected, pwalletIn, std::placeholders::_1));
+    conns.BlockDisconnected = g_signals.m_internals->BlockDisconnected.connect(std::bind(&CValidationInterface::BlockDisconnected, pwalletIn, std::placeholders::_1, std::placeholders::_2));
     conns.TransactionRemovedFromMempool = g_signals.m_internals->TransactionRemovedFromMempool.connect(std::bind(&CValidationInterface::TransactionRemovedFromMempool, pwalletIn, std::placeholders::_1));
     conns.ChainStateFlushed = g_signals.m_internals->ChainStateFlushed.connect(std::bind(&CValidationInterface::ChainStateFlushed, pwalletIn, std::placeholders::_1));
     conns.BlockChecked = g_signals.m_internals->BlockChecked.connect(std::bind(&CValidationInterface::BlockChecked, pwalletIn, std::placeholders::_1, std::placeholders::_2));
@@ -158,9 +158,10 @@ void CMainSignals::BlockConnected(const std::shared_ptr<const CBlock> &pblock, c
     });
 }
 
-void CMainSignals::BlockDisconnected(const std::shared_ptr<const CBlock> &pblock) {
-    m_internals->m_schedulerClient.AddToProcessQueue([pblock, this] {
-        m_internals->BlockDisconnected(pblock);
+void CMainSignals::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
+{
+    m_internals->m_schedulerClient.AddToProcessQueue([pblock, pindex, this] {
+        m_internals->BlockDisconnected(pblock, pindex);
     });
 }
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -114,7 +114,7 @@ protected:
      *
      * Called on a background thread.
      */
-    virtual void BlockDisconnected(const std::shared_ptr<const CBlock> &block) {}
+    virtual void BlockDisconnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex) {}
     /**
      * Notifies listeners of the new active block chain on-disk.
      *
@@ -178,7 +178,7 @@ public:
     void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
     void TransactionAddedToMempool(const CTransactionRef &);
     void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex, const std::shared_ptr<const std::vector<CTransactionRef>> &);
-    void BlockDisconnected(const std::shared_ptr<const CBlock> &);
+    void BlockDisconnected(const std::shared_ptr<const CBlock>&, const CBlockIndex* pindex);
     void ChainStateFlushed(const CBlockLocator &);
     void BlockChecked(const CBlock&, const CValidationState&);
     void NewPoWValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1412,7 +1412,8 @@ void CWallet::TransactionRemovedFromMempool(const CTransactionRef &ptx) {
     }
 }
 
-void CWallet::BlockConnected(const CBlock& block, const std::vector<CTransactionRef>& vtxConflicted) {
+void CWallet::BlockConnected(const CBlock& block, const std::vector<CTransactionRef>& vtxConflicted, int height)
+{
     const uint256& block_hash = block.GetHash();
     auto locked_chain = chain().lock();
     LOCK(cs_wallet);
@@ -1436,7 +1437,8 @@ void CWallet::BlockConnected(const CBlock& block, const std::vector<CTransaction
     m_last_block_processed = block_hash;
 }
 
-void CWallet::BlockDisconnected(const CBlock& block) {
+void CWallet::BlockDisconnected(const CBlock& block, int height)
+{
     auto locked_chain = chain().lock();
     LOCK(cs_wallet);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1412,7 +1412,8 @@ void CWallet::TransactionRemovedFromMempool(const CTransactionRef &ptx) {
     }
 }
 
-void CWallet::BlockConnected(const CBlock& block, const std::vector<CTransactionRef>& vtxConflicted, int height)
+void CWallet::BlockConnected(const CBlock& block, const std::vector<CTransactionRef>& vtxConflicted,
+		int height, FlatFilePos undo_pos)
 {
     const uint256& block_hash = block.GetHash();
     auto locked_chain = chain().lock();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1069,8 +1069,8 @@ public:
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose=true);
     void LoadToWallet(const CWalletTx& wtxIn) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
-    void BlockConnected(const CBlock& block, const std::vector<CTransactionRef>& vtxConflicted) override;
-    void BlockDisconnected(const CBlock& block) override;
+    void BlockConnected(const CBlock& block, const std::vector<CTransactionRef>& vtxConflicted, int height) override;
+    void BlockDisconnected(const CBlock& block, int height) override;
     void UpdatedBlockTip() override;
     int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1069,7 +1069,7 @@ public:
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose=true);
     void LoadToWallet(const CWalletTx& wtxIn) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
-    void BlockConnected(const CBlock& block, const std::vector<CTransactionRef>& vtxConflicted, int height) override;
+    void BlockConnected(const CBlock& block, const std::vector<CTransactionRef>& vtxConflicted, int height, FlatFilePos undo_pos) override;
     void BlockDisconnected(const CBlock& block, int height) override;
     void UpdatedBlockTip() override;
     int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -186,7 +186,7 @@ void CZMQNotificationInterface::BlockConnected(const std::shared_ptr<const CBloc
     }
 }
 
-void CZMQNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock)
+void CZMQNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected)
 {
     for (const CTransactionRef& ptx : pblock->vtx) {
         // Do a normal notify for each transaction removed in block disconnection

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -29,7 +29,7 @@ protected:
     // CValidationInterface
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted) override;
-    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
 
 private:


### PR DESCRIPTION
Right now, when bitcoind starts, we have multiple rescan loops reading the same scan ranges repeatedly out of order instead of just once in order.

This work moves the rescan logic on the node side in a new thread to be used both by wallets and indexes. To do so they need to respect the same class model, currently, index is a direct consumer of CValidationInterface, 1ff4272 makes it a client of Chain interface. 

This is first part, still need to clean the wallet side and comment it better. 

Work in progress, don't bother for a low-level review now, just commits order, general changes and new classes. There is currently a performance hit, I have ideas on why, working on the new thread loop to make it better.

Proposal & discussion : https://gist.github.com/ariard/89f9bcc3a7ab9576fc6d15d251032cfa